### PR TITLE
Version 0.2.0 with major internal changes

### DIFF
--- a/mktestimg.c
+++ b/mktestimg.c
@@ -9,7 +9,7 @@
 #define MKTESTIMG_VERSION_MAJOR 0
 #define MKTESTIMG_VERSION_MINOR 1
 #define MKTESTIMG_VERSION_PATCH 1
-#define MKTESTIMG_VERSION_STR "0.1.1"
+#define MKTESTIMG_VERSION_STR "0.2.0"
 
 #define STB_IMAGE_WRITE_IMPLEMENTATION
 #include "stb_image_write.h"
@@ -22,87 +22,123 @@ enum {
     FORMAT_COUNT,
 };
 
-char *copystr(const char *string) {
-    long len = strlen(string); 
-    char *out = malloc(sizeof(char) * (len + 1));
-    strcpy(out, string); 
-    out[len] = '\0';
+char* copy_str(const char* string) {
+    if (string == NULL) {
+        fprintf(stderr, "error: The string cannot be empty.\n");
+        exit(EXIT_FAILURE);
+    }
+
+    long len = strlen(string) + 1;
+    char* out = malloc(len);
+
+    strcpy(out, string);
+    out[strcspn(out, "\n")] = 0;
+
     return out;
 }
 
-void usage(char *prog) {
-    printf("usage: %s [-v] -w <width> -h <height> [-f <format>] [-c <channels>] [-o] <output>\n", prog);
-    printf("width and height have to be non-zero. channels can be 3 or 4.\n");
-    printf("available formats: png: %d, jpg: %d, bmp: %d\n", FORMAT_PNG, FORMAT_JPG, FORMAT_BMP);
+/**
+ * @brief Display the command-line manual.
+ *
+ * @param prog Executable name
+ */
+void usage(const char* prog) {
+    printf("Usage: %s [-v] -w <width> -h <height> [-f <format>] "
+           "[-c <channels>] [-o <output>]\n\n"
+           "  - <width> and <height> must be non-zero\n"
+           "  - <channels> can be 3 or 4\n"
+           "  - <formats> available:\n"
+           "      png: %d, jpg: %d, bmp: %d\n",
+           prog, FORMAT_PNG, FORMAT_JPG, FORMAT_BMP);
 }
 
-int main(int argc, char **argv) {
-    if (argc < 3) {
-        usage(argv[0]);
-        return 0;
+int main(int argc, char** argv) {
+    if (argc == 2 && !strcmp(argv[1], "-v")) {
+        printf("%s v%s\n", argv[0], MKTESTIMG_VERSION_STR);
+        return EXIT_SUCCESS;
     }
 
-    char *output = NULL; 
+    if (argc < 3) {
+        usage(argv[0]);
+        return EXIT_FAILURE;
+    }
+
+    char* output = NULL;
     int width = 0, height = 0, channels = 0, format = 0;
 
-    for (int i = 1; i < argc; i++) {
-        if (!strcmp(argv[i], "-v")) {
-            printf("%s v%s\n", argv[0], MKTESTIMG_VERSION_STR);
-            return 0;
-        }
-        else if (!strcmp(argv[i], "-w") && width == 0) {
+    for (int i = 1; i < argc; i++)
+        if (!strcmp(argv[i], "-w") && width == 0)
             width = atoi(argv[++i]);
-        }
-        else if (!strcmp(argv[i], "-h") && height == 0) {
+
+        else if (!strcmp(argv[i], "-h") && height == 0)
             height = atoi(argv[++i]);
-        }
-        else if (!strcmp(argv[i], "-f") && format == 0) {
+
+        else if (!strcmp(argv[i], "-f") && format == 0)
             format = atoi(argv[++i]);
-        }
-        else if (!strcmp(argv[i], "-c") && channels == 0) {
+
+        else if (!strcmp(argv[i], "-c") && channels == 0)
             channels = atoi(argv[++i]);
-        }
+
         else {
-            if (!i) continue;
+            if (!i)
+                continue;
             if (!output) {
-                if (!strcmp(argv[i], "-o")) i++;
-                output = copystr(argv[i]);
-            }
-            else {
-                printf("unknown argument: %s\n", argv[i]);
-                usage(argv[0]);
-                return 0;
+                if (!strcmp(argv[i], "-o"))
+                    i++;
+                output = copy_str(argv[i]);
+            } else {
+                printf("Unexpected field: %s\n"
+                       "Try typing: %s - to get help.\n",
+                       argv[i], argv[0]);
+                return EXIT_FAILURE;
             }
         }
+
+    if (width == 0 || height == 0 || format == 0 || channels == 0 ||
+        output == 0) {
+        fprintf(stderr, "error: Arguments are malformed.\n");
+        return EXIT_FAILURE;
     }
 
     if (!(width && height)) {
-        fprintf(stderr, "%s: width or height cannot be zero\n", argv[0]);
-        return 0;
+        fprintf(stderr, "%s: width or height cannot be zero!\n", argv[0]);
+        return EXIT_FAILURE;
     }
 
-    if (!format || format >= FORMAT_COUNT) format = FORMAT_PNG;
-    if (!channels || channels > 4 || channels < 3) channels = 4;
-    if (!output) output = copystr("out.img");
+    if (!format || format >= FORMAT_COUNT)
+        format = FORMAT_PNG;
+    if (!channels || channels > 4 || channels < 3)
+        channels = 4;
+    if (!output)
+        output = copy_str("out.jpg");
 
-    printf("width: %d\nheight: %d\nchannels: %d\noutput: %s\n", width, height, channels, output);
+    printf("width: %d\n"
+           "height: %d\n"
+           "channels: %d\n"
+           "output: %s\n",
+           width, height, channels, output);
 
     stbi_write_png_compression_level = 1;
-    char *data = malloc(sizeof(char) * width * height * channels);
-    
-    for (int i = 0; i < width * height; i++) {
-        data[i * channels + 0] = 255;
+    char* data = malloc(width * height * channels);
+
+    for (int i = 0, res = width * height; i < res; i++) {
+        data[i * channels + 0] = (char)255;
         data[i * channels + 1] = 0;
         data[i * channels + 2] = 0;
-        data[i * channels + 3] = 255;
+        data[i * channels + 3] = (char)255;
     }
 
-    if (format = FORMAT_PNG) stbi_write_png(output, width, height, channels, data, width * channels);
-    else if (format == FORMAT_BMP) stbi_write_bmp(output, width, height, channels, data);
-    else if (format == FORMAT_JPG) stbi_write_jpg(output, width, height, channels, data, 1);
+    if (format == FORMAT_PNG)
+        stbi_write_png(output, width, height, channels, data, width * channels);
+    else if (format == FORMAT_BMP)
+        stbi_write_bmp(output, width, height, channels, data);
+    else if (format == FORMAT_JPG)
+        stbi_write_jpg(output, width, height, channels, data, 1);
 
-    printf("image created successfully: %s\n", output);
+    printf("Image creation successful: %s\n", output);
+
     free(output);
     free(data);
+
     return 0;
 }


### PR DESCRIPTION
**This is a significantly improved version of the mktestimg program. The following changes were made:**

  1. Version upgrade from 0.1.1 to 0.2.0
  2. copy_str() must be checked for NULL, otherwise segfault is possible
  3. sizeof(char) is equivalent to one, so not necessary
  4. Redundant code removed
  5. Output experience enhanced by formatting text
  6. Significantly improved code's reliability and readability
  7. Assigning int 255 to char overflows, explicit conversion given
  8. Fixed segfault and added ability to tackle malformed args